### PR TITLE
Make tests work after split from php-src

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,15 @@
+# PDO_OCI TESTS
+
+The PDO_OCI tests augment the generic PDO tests.
+
+To run the PDO tests for PDO_OCI, execute commands similar to:
+
+    export PDO_TEST_DIR=/wherever/php-src/ext/pdo/tests/
+    export PDO_OCI_TEST_DIR=/wherever/pecl-database-pdo_oci/tests/
+
+    export PDO_OCI_TEST_DSN='oci:dbname=localhost/freepdb1;charset=AL32UTF8'
+    export PDO_OCI_TEST_USER=system
+    export PDO_OCI_TEST_PASS=oracle
+
+    cd /wherever/pecl-database-pdo_oci
+    php /wherever/php-src/run-tests.php --set-timeout 600 ./tests

--- a/tests/bug41996.phpt
+++ b/tests/bug41996.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require __DIR__.'/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 
 $stmt = $db->prepare('SELECT rowid FROM dual');
 $stmt->execute();

--- a/tests/bug44301.phpt
+++ b/tests/bug44301.phpt
@@ -5,14 +5,14 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require __DIR__.'/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 putenv("PDO_OCI_TEST_ATTR=" . serialize(array(PDO::ATTR_PERSISTENT => true)));
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 try {
@@ -24,5 +24,5 @@ try {
 $db = null;
 ?>
 --EXPECTF--
-SQLSTATE[HY000]: General error: 942 OCIStmtExecute: ORA-00942: table or view does not exist
+SQLSTATE[HY000]: General error: 942 OCIStmtExecute: ORA-00942: table or view %sdoes not exist
  (%s%epdo_oci%eoci_statement.c:%d)

--- a/tests/bug46274.phpt
+++ b/tests/bug46274.phpt
@@ -5,16 +5,23 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require __DIR__.'/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
-?>
 --FILE--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+
+$db->exec("begin
+             execute immediate 'drop table test46274';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 
 $db->beginTransaction();
 
@@ -51,9 +58,15 @@ var_dump($res->fetch());
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test46274");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test46274';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 array(2) {

--- a/tests/bug46274_2.phpt
+++ b/tests/bug46274_2.phpt
@@ -5,16 +5,24 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require __DIR__.'/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+
+$db->exec("begin
+             execute immediate 'drop table test46274_2';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 
 $db->beginTransaction();
 
@@ -56,9 +64,15 @@ fclose($row[0]);
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test46274_2");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test46274_2';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECTF--
 array(2) {

--- a/tests/bug54379.phpt
+++ b/tests/bug54379.phpt
@@ -5,17 +5,23 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require __DIR__.'/../../pdo/tests/pdo_test.inc';
-if (!preg_match('/charset=.*utf8/i', getenv('PDOTEST_DSN')))
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 die('skip not UTF8 DSN');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
+$db->exec("begin
+             execute immediate 'drop table test54379';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 $db->exec("CREATE TABLE test54379 (col1 NVARCHAR2(20))");
 $db->exec("INSERT INTO test54379 VALUES('12345678901234567890')");
 $db->exec("INSERT INTO test54379 VALUES('あいうえおかきくけこさしすせそたちつてと')");
@@ -25,9 +31,15 @@ var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test54379");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test54379';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 array(2) {

--- a/tests/bug57702.phpt
+++ b/tests/bug57702.phpt
@@ -5,18 +5,25 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require('ext/pdo/tests/pdo_test.inc');
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 
 // Note the PDO test setup sets PDO::ATTR_STRINGIFY_FETCHES to true
 // (and sets PDO::ATTR_CASE to PDO::CASE_LOWER)
 
+$db->exec("begin
+             execute immediate 'drop table test57702';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 $query = "create table test57702 (id number, data1 blob, data2 blob)";
 $stmt = $db->prepare($query);
 $stmt->execute();
@@ -141,9 +148,15 @@ print "done\n";
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test57702");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test57702';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 First Query

--- a/tests/bug60994.phpt
+++ b/tests/bug60994.phpt
@@ -9,17 +9,23 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require __DIR__.'/../../pdo/tests/pdo_test.inc';
-if (!strpos(strtolower(getenv('PDOTEST_DSN')), 'charset=al32utf8')) die('skip expected output valid for AL32UTF8 character set');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 $dbh = PDOTest::factory();
 $dbh->setAttribute(PDO::ATTR_CASE, PDO::CASE_NATURAL);
 $dbh->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
+$dbh->exec("begin
+              execute immediate 'drop table pdo_oci_bug60994';
+              exception when others then
+                if sqlcode <> -942 then
+                  raise;
+                end if;
+            end;");
 $dbh->exec('CREATE TABLE pdo_oci_bug60994 (id NUMBER, data CLOB, data2 NCLOB)');
 
 $id = null;
@@ -110,9 +116,15 @@ if ($string4 != $stream4 || $stream4 != stream_get_contents($row['DATA2'])) {
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "pdo_oci_bug60994");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table pdo_oci_bug60994';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 Test 1:  j

--- a/tests/bug_33707.phpt
+++ b/tests/bug_33707.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require __DIR__.'/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
 $rs = $db->query('select blah from a_table_that_does_not_exist');
@@ -26,6 +26,6 @@ array(3) {
   [1]=>
   int(942)
   [2]=>
-  string(%d) "OCIStmtExecute: ORA-00942: table or view does not exist
+  string(%d) "OCIStmtExecute: ORA-00942: table or view %sdoes not exist
  (%s:%d)"
 }

--- a/tests/checkliveness.phpt
+++ b/tests/checkliveness.phpt
@@ -5,14 +5,14 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require __DIR__.'/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 
 $dsn = getenv('PDOTEST_DSN');
 $user = getenv('PDOTEST_USER');

--- a/tests/common.phpt
+++ b/tests/common.phpt
@@ -6,20 +6,20 @@ pdo_oci
 # magic auto-configuration
 
 $config = array(
-	'TESTS' => 'ext/pdo/tests'
+    'TESTS' => getenv('PDO_TEST_DIR')
 );
 
+putenv('ORA_SUPPRESS_ERROR_URL=TRUE');    // suppress Oracle Database 23ai error message URLs
 
 if (false !== getenv('PDO_OCI_TEST_DSN')) {
-	# user set them from their shell
-	$config['ENV']['PDOTEST_DSN'] = getenv('PDO_OCI_TEST_DSN');
-	$config['ENV']['PDOTEST_USER'] = getenv('PDO_OCI_TEST_USER');
-	$config['ENV']['PDOTEST_PASS'] = getenv('PDO_OCI_TEST_PASS');
-	$config['ENV']['PDOTEST_ATTR'] = getenv('PDO_OCI_TEST_ATTR');
+    $config['ENV']['PDOTEST_DSN'] = getenv('PDO_OCI_TEST_DSN');
+    $config['ENV']['PDOTEST_USER'] = getenv('PDO_OCI_TEST_USER');
+    $config['ENV']['PDOTEST_PASS'] = getenv('PDO_OCI_TEST_PASS');
+    $config['ENV']['PDOTEST_ATTR'] = getenv('PDO_OCI_TEST_ATTR');
 } else {
-	$config['ENV']['PDOTEST_DSN'] = 'oci:dbname=localhost/xe;charset=WE8MSWIN1252';
-	$config['ENV']['PDOTEST_USER'] = 'SYSTEM';
-	$config['ENV']['PDOTEST_PASS'] = 'oracle';
+    $config['ENV']['PDOTEST_DSN'] = 'oci:dbname=localhost/freepdb1;charset=AL32UTF8';
+    $config['ENV']['PDOTEST_USER'] = 'system';
+    $config['ENV']['PDOTEST_PASS'] = 'oracle';
 }
 
 return $config;

--- a/tests/oci_success_with_info.phpt
+++ b/tests/oci_success_with_info.phpt
@@ -8,12 +8,14 @@ This test frequently fails in CI
 --SKIPIF--
 <?php
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+PDOTest::skip();
 ?>
 --FILE--
 <?php
 
 function connectAsAdmin(): PDO {
-    return PDOTest::test_factory(__DIR__ . '/../../pdo_oci/tests/common.phpt');
+    return PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 }
 
 function connectAsUser(string $username, string $password): PDO {
@@ -59,7 +61,7 @@ SQL
     );
 }
 
-require __DIR__ . '/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $conn = connectAsAdmin();
 
@@ -98,7 +100,7 @@ array(3) {
   [1]=>
   int(28002)
   [2]=>
-  string(%d) "OCISessionBegin: OCI_SUCCESS_WITH_INFO: ORA-28002: %s
+  string(%d) "OCISessionBegin: OCI_SUCCESS_WITH_INFO: ORA-%s
  (%s:%d)"
 }
 array(3) {

--- a/tests/pdo_oci_attr_action.phpt
+++ b/tests/pdo_oci_attr_action.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $query = 'select action from v$session where sid = sys_context(\'USERENV\', \'SID\')';
 

--- a/tests/pdo_oci_attr_autocommit_1.phpt
+++ b/tests/pdo_oci_attr_autocommit_1.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $dbh = PDOTest::factory();
 
@@ -37,6 +37,13 @@ var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
 // Use 2nd connection to check that autocommit does commit
 
 echo "Insert data\n";
+$dbh->exec("begin
+              execute immediate 'drop table test_pdo_oci_attr_autocommit_1';
+              exception when others then
+                if sqlcode <> -942 then
+                  raise;
+                end if;
+            end;");
 $dbh->exec("create table test_pdo_oci_attr_autocommit_1 (col1 varchar2(20))");
 $dbh->exec("insert into test_pdo_oci_attr_autocommit_1 (col1) values ('some data')");
 
@@ -54,9 +61,15 @@ echo "Done\n";
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test_pdo_oci_attr_autocommit_1");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test_pdo_oci_attr_autocommit_1';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 PDO::ATTR_AUTOCOMMIT: Default: bool(true)

--- a/tests/pdo_oci_attr_autocommit_2.phpt
+++ b/tests/pdo_oci_attr_autocommit_2.phpt
@@ -5,17 +5,24 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 $dbh = PDOTest::factory();
 
 $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
+$dbh->exec("begin
+              execute immediate 'drop table test_pdo_oci_attr_autocommit_2';
+              exception when others then
+                if sqlcode <> -942 then
+                  raise;
+                end if;
+            end;");
 $dbh->exec("create table test_pdo_oci_attr_autocommit_2 (col1 varchar2(25))");
 
 echo "Test 1 Check beginTransaction insertion\n";
@@ -103,14 +110,20 @@ echo "Done\n";
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test_pdo_oci_attr_autocommit_2");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test_pdo_oci_attr_autocommit_2';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECTF--
 Test 1 Check beginTransaction insertion
 Test 2 Cause an exception and test beginTransaction rollback
-Caught expected exception at line 33
+Caught expected exception at line %d
 SQLSTATE[HY000]: General error: 12899 OCIStmtExecute: ORA-12899: %s
 %s
 Test 3 Setting ATTR_AUTOCOMMIT to true will commit and end the transaction

--- a/tests/pdo_oci_attr_autocommit_3.phpt
+++ b/tests/pdo_oci_attr_autocommit_3.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 // Check connection can be created with AUTOCOMMIT off
 putenv('PDOTEST_ATTR='.serialize(array(PDO::ATTR_AUTOCOMMIT=>false)));
@@ -23,6 +23,14 @@ print "PDO::ATTR_AUTOCOMMIT: ";
 var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
 
 echo "Insert data\n";
+
+$dbh->exec("begin
+              execute immediate 'drop table test_pdo_oci_attr_autocommit_3';
+              exception when others then
+                if sqlcode <> -942 then
+                  raise;
+                end if;
+            end;");
 
 $dbh->exec("create table test_pdo_oci_attr_autocommit_3 (col1 varchar2(20))");
 
@@ -43,9 +51,15 @@ echo "Done\n";
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test_pdo_oci_attr_autocommit_3");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test_pdo_oci_attr_autocommit_3';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 PDO::ATTR_AUTOCOMMIT: bool(false)

--- a/tests/pdo_oci_attr_call_timeout.phpt
+++ b/tests/pdo_oci_attr_call_timeout.phpt
@@ -6,7 +6,7 @@ pdo_oci
 --SKIPIF--
 <?php
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 if (strcasecmp(getenv('PDOTEST_USER'), "system") && strcasecmp(getenv('PDOTEST_USER'), "sys")) {
     die("skip needs to be run as a user with access to DBMS_LOCK");
@@ -22,7 +22,7 @@ if (!(isset($matches[0]) && $matches[0] >= 18)) {
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 function mysleep($dbh, $t)
 {

--- a/tests/pdo_oci_attr_case.phpt
+++ b/tests/pdo_oci_attr_case.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 function do_query1($dbh)
 {

--- a/tests/pdo_oci_attr_client.phpt
+++ b/tests/pdo_oci_attr_client.phpt
@@ -5,13 +5,12 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
-?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $dbh = PDOTest::factory();
 

--- a/tests/pdo_oci_attr_client_identifier.phpt
+++ b/tests/pdo_oci_attr_client_identifier.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $query = 'select client_identifier from v$session where sid = sys_context(\'USERENV\', \'SID\')';
 

--- a/tests/pdo_oci_attr_client_info.phpt
+++ b/tests/pdo_oci_attr_client_info.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $query = 'select client_info from v$session where sid = sys_context(\'USERENV\', \'SID\')';
 

--- a/tests/pdo_oci_attr_drivername.phpt
+++ b/tests/pdo_oci_attr_drivername.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require __DIR__ . '/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $dbh = PDOTest::factory();
 var_dump($dbh->getAttribute(PDO::ATTR_DRIVER_NAME));

--- a/tests/pdo_oci_attr_module.phpt
+++ b/tests/pdo_oci_attr_module.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $query = 'select module from v$session where sid = sys_context(\'USERENV\', \'SID\')';
 

--- a/tests/pdo_oci_attr_nulls_1.phpt
+++ b/tests/pdo_oci_attr_nulls_1.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 function do_query($dbh)
 {

--- a/tests/pdo_oci_attr_prefetch_1.phpt
+++ b/tests/pdo_oci_attr_prefetch_1.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $dbh = PDOTest::factory();
 

--- a/tests/pdo_oci_attr_prefetch_2.phpt
+++ b/tests/pdo_oci_attr_prefetch_2.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $dbh = PDOTest::factory();
 

--- a/tests/pdo_oci_attr_server.phpt
+++ b/tests/pdo_oci_attr_server.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $dbh = PDOTest::factory();
 

--- a/tests/pdo_oci_class_constants.phpt
+++ b/tests/pdo_oci_class_constants.phpt
@@ -5,13 +5,13 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $expected = [
     'OCI_ATTR_CLIENT_INFO'        => true,

--- a/tests/pdo_oci_debugdumpparams.phpt
+++ b/tests/pdo_oci_debugdumpparams.phpt
@@ -5,12 +5,12 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $db = PDOTest::factory();
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
@@ -25,8 +25,8 @@ $stmt = $db->query("
 ");
 var_dump($stmt->debugDumpParams());
 ?>
---EXPECT--
-SQL: [844] 
+--EXPECTF--
+SQL: [844]%s
     SELECT '
         Dumps the information contained by a prepared statement directly on the output. It will provide the SQL query in use, the number of parameters used (Params), the list of parameters, with their name, type (paramtype) as an integer, their key name or position, and the position in the query (if this is supported by the PDO driver, otherwise, it will be -1).
         This is a debug function, which dump directly the data on the normal output.

--- a/tests/pdo_oci_fread_1.phpt
+++ b/tests/pdo_oci_fread_1.phpt
@@ -5,14 +5,14 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 if (!strpos(strtolower(getenv('PDOTEST_DSN')), 'charset=we8mswin1252')) die('skip expected output valid for WE8MSWIN1252 character set');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $dbh = PDOTest::factory();
 
@@ -20,12 +20,19 @@ $dbh->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
 // Initialization
 $stmtarray = array(
+    "begin
+       execute immediate 'drop table test_oci_fread_1';
+       exception when others then
+         if sqlcode <> -942 then
+           raise;
+         end if;
+     end;",
     "create table test_oci_fread_1 (id number, data clob)",
     "declare
-    lob1 clob := 'abc' || lpad('j',4020,'j') || 'xyz';
-   begin
-    insert into test_oci_fread_1 (id,data) values (1, lob1);
-  end;"
+     lob1 clob := 'abc' || lpad('j',4020,'j') || 'xyz';
+     begin
+       insert into test_oci_fread_1 (id,data) values (1, lob1);
+     end;"
 );
 
 foreach ($stmtarray as $stmt) {
@@ -47,9 +54,15 @@ fclose($sh);
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, test_oci_fread_1");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test_oci_fread_1';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 Test 1

--- a/tests/pdo_oci_phpinfo.phpt
+++ b/tests/pdo_oci_phpinfo.phpt
@@ -5,12 +5,12 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 $db = PDOTest::factory();
 
 ob_start();

--- a/tests/pdo_oci_quote1.phpt
+++ b/tests/pdo_oci_quote1.phpt
@@ -5,15 +5,22 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require __DIR__ . '/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 $db = PDOTest::factory();
 
+$db->exec("begin
+             execute immediate 'drop table test_pdo_oci_quote1';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 $db->query("create table test_pdo_oci_quote1 (t varchar2(100))");
 $stmt = $db->prepare('select * from test_pdo_oci_quote1');
 
@@ -39,9 +46,15 @@ echo "Done\n";
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test_pdo_oci_quote1");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test_pdo_oci_quote1';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 Unquoted : string(0) ""

--- a/tests/pdo_oci_stmt_getcolumnmeta.phpt
+++ b/tests/pdo_oci_stmt_getcolumnmeta.phpt
@@ -5,7 +5,7 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
@@ -13,10 +13,17 @@ PDOTest::skip();
 
 echo "Preparations before the test\n";
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 try {
     $db = PDOTest::factory();
 
+    $db->exec("begin
+                 execute immediate 'drop table test_pdo_oci_stmt_getcolumnmeta';
+                 exception when others then
+                   if sqlcode <> -942 then
+                     raise;
+                   end if;
+               end;");
     $db->exec("CREATE TABLE test_pdo_oci_stmt_getcolumnmeta(id INT)");
 
     $db->beginTransaction();
@@ -140,17 +147,13 @@ try {
 
     function test_meta(&$db, $offset, $sql_type, $value, $native_type, $pdo_type) {
 
-        $db->exec(<<<SQL
-BEGIN
-   EXECUTE IMMEDIATE 'DROP TABLE test_pdo_oci_stmt_getcolumnmeta';
-EXCEPTION
-   WHEN OTHERS THEN
-      IF SQLCODE != -942 THEN
-         RAISE;
-      END IF;
-END;
-SQL
-);
+        $db->exec("begin
+                     execute immediate 'drop table test_pdo_oci_stmt_getcolumnmeta';
+                     exception when others then
+                       if sqlcode <> -942 then
+                         raise;
+                       end if;
+                   end;");
 
         $sql = sprintf('CREATE TABLE test_pdo_oci_stmt_getcolumnmeta(id INT, label %s)', $sql_type);
         $stmt = $db->prepare($sql);
@@ -222,17 +225,13 @@ SQL
     test_meta($db, 370, 'RAW(256)'      , str_repeat('b', 256) , 'RAW'     , PDO::PARAM_STR);
 
 
-    $db->exec(<<<SQL
-BEGIN
-   EXECUTE IMMEDIATE 'DROP TABLE test_pdo_oci_stmt_getcolumnmeta';
-EXCEPTION
-   WHEN OTHERS THEN
-      IF SQLCODE != -942 THEN
-         RAISE;
-      END IF;
-END;
-SQL
-);
+    $db->exec("begin
+                     execute immediate 'drop table test_pdo_oci_stmt_getcolumnmeta';
+                     exception when others then
+                       if sqlcode <> -942 then
+                         raise;
+                       end if;
+                   end;");
     echo "Test 2.6 testing function return\n";
 
     $stmt = $db->query('SELECT count(*) FROM dual');
@@ -296,9 +295,15 @@ print "done!";
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test_pdo_oci_stmt_getcolumnmeta");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test_pdo_oci_stmt_getcolumnmeta';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 Preparations before the test

--- a/tests/pdo_oci_stream_1.phpt
+++ b/tests/pdo_oci_stream_1.phpt
@@ -5,14 +5,14 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 if (!strpos(strtolower(getenv('PDOTEST_DSN')), 'charset=we8mswin1252')) die('skip expected output valid for WE8MSWIN1252 character set');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $dbh = PDOTest::factory();
 
@@ -20,6 +20,13 @@ $dbh->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
 // Initialization
 $stmtarray = array(
+    "begin
+       execute immediate 'drop table test_pdo_oci_stream_1';
+       exception when others then
+         if sqlcode <> -942 then
+           raise;
+         end if;
+     end;",
     "create table test_pdo_oci_stream_1 (id number, data clob)",
 );
 
@@ -75,9 +82,15 @@ echo 'Read '.stream_get_contents($r['data'], -1, 30000)."\n";      // jjjxyz
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, test_pdo_oci_stream_1");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test_pdo_oci_stream_1';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 Test 1

--- a/tests/pdo_oci_stream_2.phpt
+++ b/tests/pdo_oci_stream_2.phpt
@@ -6,16 +6,23 @@ pdo_oci
 --SKIPIF--
 <?php
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require(__DIR__ . '/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 
 $db = PDOTest::factory();
 
+$db->exec("begin
+             execute immediate 'drop table test_pdo_oci_stream_2';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 $query = "create table test_pdo_oci_stream_2 (id number, data1 blob, data2 blob)";
 $stmt = $db->prepare($query);
 $stmt->execute();
@@ -113,9 +120,15 @@ echo "Fetch operation done!\n";
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test_pdo_oci_stream_2");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test_pdo_oci_stream_2';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 ?>
 --EXPECT--
 Inserting 1000 Records ... Done

--- a/tests/pdo_oci_templob_1.phpt
+++ b/tests/pdo_oci_templob_1.phpt
@@ -5,14 +5,14 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?PHP
 
-require('ext/pdo/tests/pdo_test.inc');
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
 
 $clobquery1 = "select TO_CLOB('Hello World') CLOB_DATA from dual";
 $clobquery2 = "select TO_CLOB('Hello World') CLOB_DATA from dual";

--- a/tests/pecl_bug_11345.phpt
+++ b/tests/pecl_bug_11345.phpt
@@ -5,7 +5,7 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--

--- a/tests/pecl_bug_6364.phpt
+++ b/tests/pecl_bug_6364.phpt
@@ -6,18 +6,26 @@ pdo_oci
 --SKIPIF--
 <?php
 if (getenv('SKIP_ASAN')) die('xleak leaks memory under asan');
-require(__DIR__.'/../../pdo/tests/pdo_test.inc');
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 PDOTest::skip();
 ?>
 --FILE--
 <?php
 
-require __DIR__ . '/../../pdo/tests/pdo_test.inc';
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
 $dbh = PDOTest::factory();
+
+$dbh->exec("begin
+              execute immediate 'drop table test6364';
+              exception when others then
+                if sqlcode <> -942 then
+                  raise;
+                end if;
+            end;");
 
 $dbh->exec ("create table test6364 (c1 varchar2(10), c2 varchar2(10), c3 varchar2(10), c4 varchar2(10), c5 varchar2(10))");
 
-$dbh->exec ("create procedure test6364_sp(p1 IN varchar2, p2 IN varchar2, p3 IN varchar2, p4 OUT varchar2, p5 OUT varchar2) as begin insert into test6364 (c1, c2, c3) values (p1, p2, p3); p4 := 'val4'; p5 := 'val5'; end;");
+$dbh->exec ("create or replace procedure test6364_sp(p1 IN varchar2, p2 IN varchar2, p3 IN varchar2, p4 OUT varchar2, p5 OUT varchar2) as begin insert into test6364 (c1, c2, c3) values (p1, p2, p3); p4 := 'val4'; p5 := 'val5'; end;");
 
 $stmt = $dbh->prepare("call test6364_sp('p1','p2','p3',?,?)");
 
@@ -40,9 +48,15 @@ print "Done\n";
 ?>
 --CLEAN--
 <?php
-require 'ext/pdo/tests/pdo_test.inc';
-$db = PDOTest::test_factory('ext/pdo_oci/tests/common.phpt');
-PDOTest::dropTableIfExists($db, "test6364");
+require(getenv('PDO_TEST_DIR').'/pdo_test.inc');
+$db = PDOTest::test_factory(getenv('PDO_OCI_TEST_DIR').'/common.phpt');
+$db->exec("begin
+             execute immediate 'drop table test6364';
+             exception when others then
+               if sqlcode <> -942 then
+                 raise;
+               end if;
+           end;");
 $db->exec("DROP PROCEDURE test6364_sp");
 ?>
 --EXPECT--


### PR DESCRIPTION
Any comments on this way of running tests?  

Since PDO_OCI testing needs the PDO generic tests, I will assume that the PHP src has been cloned.

Two new environment variables are referenced:

- `PDO_TEST_DIR` which is the location of the generic PDO tests, e.g. `/wherever/php-src/ext/pdo/tests/`
- `PDO_OCI_TEST_DIR` which is the location of the PDO_OCI tests, e.g. `/wherever/pecl-database-pdo_oci/tests/`, or `$(pwd)/tests`

Then tests are run similar to:

```
export PDO_OCI_TEST_DSN='oci:dbname=localhost/freepdb1;charset=AL32UTF8'
export PDO_OCI_TEST_USER=system
export PDO_OCI_TEST_PASS=oracle

cd /wherever/pecl-database-pdo_oci
php /wherever/php-src/run-tests.php --set-timeout 600 ./tests
```

So far I've tested this with PHP 8.3.  Note I reverted the calls to dropTableIfExists since that isn't available in PHP 8.3.