### PR TITLE
Revert "Always assume HAVE_OCIENVNLSCREATE"

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -150,6 +150,13 @@ if test "$PHP_PDO_OCI" != "no"; then
   PHP_ADD_LIBRARY(clntsh, 1, PDO_OCI_SHARED_LIBADD)
   PHP_ADD_LIBPATH($PDO_OCI_LIB_DIR, PDO_OCI_SHARED_LIBADD)
 
+  PHP_CHECK_LIBRARY(clntsh, OCIEnvNlsCreate,
+  [
+    AC_DEFINE(HAVE_OCIENVNLSCREATE,1,[ ])
+  ], [], [
+    -L$PDO_OCI_LIB_DIR $PDO_OCI_SHARED_LIBADD
+  ])
+
   PHP_CHECK_PDO_INCLUDES
 
   PHP_NEW_EXTENSION(pdo_oci, pdo_oci.c oci_driver.c oci_statement.c, $ext_shared,,-I$pdo_cv_inc_path)

--- a/oci_driver.c
+++ b/oci_driver.c
@@ -742,6 +742,7 @@ static int pdo_oci_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ *
 	H->prefetch = PDO_OCI_PREFETCH_DEFAULT;
 
 	/* allocate an environment */
+#ifdef HAVE_OCIENVNLSCREATE
 	if (vars[0].optval) {
 		H->charset = OCINlsCharSetNameToId(pdo_oci_Env, (const oratext *)vars[0].optval);
 		if (!H->charset) {
@@ -754,7 +755,7 @@ static int pdo_oci_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ *
 			}
 		}
 	}
-
+#endif
 	if (H->env == NULL) {
 		/* use the global environment */
 		H->env = pdo_oci_Env;


### PR DESCRIPTION
repro: https://github.com/atk4/data/commit/67bec67fb5802f075dfa66b6d7759a9485e76689

described in: https://github.com/mlocati/docker-php-extension-installer/pull/1113#issuecomment-2975552006

introduced in: https://github.com/php/pecl-database-pdo_oci/pull/1

The `HAVE_OCIENVNLSCREATE` is used to call `OCINlsCharSetNameToId` and `OCIEnvNlsCreate` conditionally and the repro above shows when these functions are called, the repro exists with segfault.

```
Program received signal SIGSEGV, Segmentation fault.
0x00007fbeb6a0a197 in kpufch () from /usr/lib/oracle/21.1/client64/lib/libclntsh.so.21.1
#0  0x00007fbeb6a0a197 in kpufch () from /usr/lib/oracle/21.1/client64/lib/libclntsh.so.21.1
#1  0x00007fbeb15f5ea5 in oci_stmt_dtor (stmt=0x7fbeaf7411c0) at /tmp/pear/temp/pdo_oci/oci_statement.c:72
#2  0x000055676ce9ab28 in php_pdo_free_statement (stmt=0x7fbeaf7411c0) at /usr/src/php/ext/pdo/pdo_stmt.c:2139
#3  0x000055676ce9ac25 in pdo_dbstmt_free_storage (std=0x7fbeaf7412f8) at /usr/src/php/ext/pdo/pdo_stmt.c:2166
#4  0x000055676d2ae898 in zend_gc_collect_cycles () at /usr/src/php/Zend/zend_gc.c:1938
#5  0x000055676d1efc1a in zif_gc_collect_cycles (execute_data=0x7fbeb9c1ac40, return_value=0x7ffdae50cc20) at /usr/src/php/Zend/zend_builtin_functions.c:93
#6  0x000055676d2125b4 in ZEND_DO_FCALL_BY_NAME_SPEC_RETVAL_UNUSED_HANDLER () at /usr/src/php/Zend/zend_vm_execute.h:1567
#7  0x000055676d291e9a in execute_ex (ex=0x7fbeb9c17020) at /usr/src/php/Zend/zend_vm_execute.h:57287
#8  0x000055676d2967b8 in zend_execute (op_array=0x7fbeb9c61140, return_value=0x0) at /usr/src/php/Zend/zend_vm_execute.h:61655
#9  0x000055676d1cc2b5 in zend_execute_scripts (type=8, retval=0x0, file_count=3) at /usr/src/php/Zend/zend.c:1895
#10 0x000055676d1106f0 in php_execute_script (primary_file=0x7ffdae50e410) at /usr/src/php/main/main.c:2529
#11 0x000055676d35a45b in do_cli (argc=15, argv=0x7fbeba19ab20) at /usr/src/php/sapi/cli/php_cli.c:966
#12 0x000055676d35b2a5 in main (argc=15, argv=0x7fbeba19ab20) at /usr/src/php/sapi/cli/php_cli.c:1341
```

Maybe this is not related to Alpine or `HAVE_OCIENVNLSCREATE` (https://github.com/mlocati/docker-php-extension-installer/issues/523#issuecomment-1533042841 detection), but as reverting this fixes our CI, we revert this for now.